### PR TITLE
Module4/owans

### DIFF
--- a/module4/contracts/OneMilNftPixels.sol
+++ b/module4/contracts/OneMilNftPixels.sol
@@ -210,3 +210,4 @@ contract OneMilNftPixels is ERC721, Ownable, IERC1363Receiver {
         revert('Unknown function call');
     }
 }
+

--- a/module4/contracts/OneMilNftPixels.sol
+++ b/module4/contracts/OneMilNftPixels.sol
@@ -70,12 +70,6 @@ contract OneMilNftPixels is ERC721, Ownable, IERC1363Receiver {
             interfaceId == type(IERC1363Receiver).interfaceId ||
             super.supportsInterface(interfaceId);
     }
-
-    // =========================
-    // Compensation withdrawals
-    // =========================
-
-    // Backward-compatible for older tests/callers:
     function withdrawCompensation(IERC1363Receiver to) public {
         _withdrawCompensation(address(to));
     }
@@ -100,10 +94,6 @@ contract OneMilNftPixels is ERC721, Ownable, IERC1363Receiver {
 
         emit WithdrawCompensation(to, due);
     }
-
-    // =========================
-    // Core pixel logic
-    // =========================
 
     function _buy(address sender, uint24 id, bytes3 colour, uint256 amount) internal {
         require(id < pixels.length, 'invalid id');
@@ -210,4 +200,3 @@ contract OneMilNftPixels is ERC721, Ownable, IERC1363Receiver {
         revert('Unknown function call');
     }
 }
-


### PR DESCRIPTION
## What

Completed Module 4 Exercises

## Why

Summary

This PR introduces critical security fixes and refactors to the OneMilNftPixels.sol contract, addressing multiple issues found during audit and ensuring compatibility with existing tests.

<img width="828" height="455" alt="Screenshot 2025-11-07 at 09 45 52" src="https://github.com/user-attachments/assets/f38fea83-026a-46fc-9184-cf70e03cbef5" />

🧩 Key Changes

Removed delegatecall vulnerability

Replaced unsafe delegatecall in _transferReceived with a whitelisted dispatcher using direct internal function calls (_buy / _update).

Prevents arbitrary function execution via user-supplied calldata.

Fixed underpayment exploit

The contract now validates purchase/update amounts using the actual ERC1363 transfer amount, not the potentially forged amount in the data payload.

Reentrancy protection applied

Implemented Checks-Effects-Interactions (CEI) pattern in withdrawCompensation.

External token transfers now occur after internal state updates to block reentrancy attacks.

Backward-compatible withdrawal handling

Added a legacy-safe overload:

Removed dependency on ReentrancyGuard

Reentrancy protection now implemented natively using CEI.

Simplifies contract inheritance and reduces bytecode size.

Input and bounds validation

Added pixel ID bounds check (require(id < pixels.length)).

Additional sanity checks to prevent invalid pixel operations.

✅ Outcome

Eliminates delegatecall abuse and amount spoofing vulnerabilities.

Protects against reentrancy during compensation withdrawals.

Maintains full backward compatibility for test environments.

Ensures safer, cleaner, and more maintainable contract structure.

📦 Developer Notes

Tests that previously called withdrawCompensation(IERC1363Receiver(this)) will continue to pass.

New direct address-based calls should use withdrawCompensationTo(address).

🧠 References

Issues addressed: EXP-OMP001 / internal audit recommendations

Solidity 0.8.x native overflow safety maintained

Compatible with OpenZeppelin v5.x ERC721 and Ownable contracts