### PR TITLE
Potential fix for code scanning alert no. 6: Code injection

### DIFF
--- a/.github/workflows/autocheck.yml
+++ b/.github/workflows/autocheck.yml
@@ -23,8 +23,9 @@ jobs:
 
       # 2. Detect the module from the PR title (e.g., module1/student-username)
       - name: Detect module from PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Parsing PR title: $PR_TITLE"
           MODULE_RAW=$(echo "$PR_TITLE" | grep -ioE '^module[0-9]+')
 


### PR DESCRIPTION
Potential fix for [https://github.com/rsksmart/rootstock-academy-dev-course/security/code-scanning/6](https://github.com/rsksmart/rootstock-academy-dev-course/security/code-scanning/6)

General fix: avoid using untrusted GitHub expression values directly inside shell scripts. Instead, assign them to environment variables in the `env:` section and read them in the script using native shell syntax (`$VAR`), ensuring they are quoted.

Best targeted fix here: in the “Detect module from PR title” step, move `${{ github.event.pull_request.title }}` from the `run:` block into an `env:` mapping, e.g.:

```yaml
- name: Detect module from PR title
  env:
    PR_TITLE: ${{ github.event.pull_request.title }}
  run: |
    echo "Parsing PR title: $PR_TITLE"
    MODULE_RAW=$(echo "$PR_TITLE" | grep -ioE '^module[0-9]+')
    ...
```

This keeps all existing behavior: `PR_TITLE` still contains the PR title, the parsing logic is unchanged, and subsequent steps that depend on `MODULE` are unaffected. We only alter how the untrusted input reaches the shell, aligning with the recommended secure pattern.

Changes needed:

- Edit `.github/workflows/autocheck.yml` in the “Detect module from PR title” step.
- Add an `env:` block that sets `PR_TITLE` from `github.event.pull_request.title`.
- Remove the direct `${{ github.event.pull_request.title }}` interpolation from the `run:` script and rely on `$PR_TITLE` instead.

No new methods, imports, or additional definitions are needed beyond this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
