### PR TITLE
module3/mayowaobi74@gmail.com

### DIFF
--- a/module3/contracts/01-contract.sol
+++ b/module3/contracts/01-contract.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
-___ solidity ^0.8.0;
+pragma solidity ^0.8.0;
 
-___ Abc {
+contract Abc {
 
-    ___() {
+    constructor() {
     }
 
 }

--- a/module3/contracts/02-primitive-variables.sol
+++ b/module3/contracts/02-primitive-variables.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 contract Cars {
 
-    ___ ___ isBlack;
-    ___ ___ doors;
-    ___ ___ owner;
+    bool public isBlack;
+    uint256 public doors;
+    address public owner;
 
     constructor() {
     }

--- a/module3/contracts/03-enum.sol
+++ b/module3/contracts/03-enum.sol
@@ -2,11 +2,11 @@ pragma solidity ^0.8.0;
 
 contract Cars {
 
-    ___ CarStatus __________
+    enum CarStatus { driving, parked }
 
     bytes3 public colour;
     uint8 public doors;
-    ___ ___ status;
+    CarStatus public status;
     address public owner;
 
     constructor() {

--- a/module3/contracts/04-struct.sol
+++ b/module3/contracts/04-struct.sol
@@ -4,11 +4,11 @@ contract Cars {
 
     enum CarStatus { driving, parked }
 
-    ___ Car {
-        ___ colour;
-        ___ doors;
-        ___ status;
-        ___ owner;
+    struct Car {
+        bytes3 colour;
+        uint8 doors;
+        CarStatus status;
+        address owner;
     }
 
     constructor() {

--- a/module3/contracts/05-dynamic-variables.sol
+++ b/module3/contracts/05-dynamic-variables.sol
@@ -11,8 +11,8 @@ contract Cars {
         address owner;
     }
 
-    ___ public numCars = ___;
-    ____(uint256 => ___) public cars;
+    uint256 public numCars = 0;
+    mapping(uint256 => Car) public cars;
 
     constructor() {
     }

--- a/module3/contracts/06-function-stub.sol
+++ b/module3/contracts/06-function-stub.sol
@@ -17,12 +17,12 @@ contract Cars {
     constructor() {
     }
 
-    ___ addCar(
-        _________
-        _________
+    function addCar(
+        bytes3 colour,
+        uint8 doors
     )
-        ___
-        returns(___ ___)
+        public
+        returns(uint256 carId)
     {
     }
 

--- a/module3/contracts/07-function-impl.sol
+++ b/module3/contracts/07-function-impl.sol
@@ -24,14 +24,14 @@ contract Cars {
         public
         returns(uint256 carId)
     {
-        ___ = ++numCars;
-        ___ memory newCar = ___(
-            ___,
-            ___,
-            CarStatus.___,
-            msg.___
+        carId = ++numCars;
+        Car memory newCar = Car(
+            colour,
+            doors,
+            CarStatus.parked,
+            msg.sender
         );
-        _________ = newCar;
+        cars[carId] = newCar;
     }
 
 }

--- a/module3/contracts/08-require.sol
+++ b/module3/contracts/08-require.sol
@@ -22,11 +22,11 @@ contract Cars {
         uint8 doors
     )
         public
-        ___
+        payable
         returns(uint256 carId)
     {
-        ___(
-            msg.___ > ___,
+        require(
+            msg.value > 0.1 ether,
             "requires payment"
         );
         carId = ++numCars;
@@ -40,15 +40,15 @@ contract Cars {
     }
 
     function statusChange(
-        uint256 ___,
+        uint256 carId,
         CarStatus newStatus
     ) public {
         require(
-            cars[carId].___ == msg.___,
+            cars[carId].owner == msg.sender,
             "only owner"
         );
         require(
-            cars[carId].___ != ___,
+            cars[carId].status != newStatus,
             "no change"
         );
         cars[carId].status = newStatus;

--- a/module3/contracts/09-function-modifier.sol
+++ b/module3/contracts/09-function-modifier.sol
@@ -44,7 +44,7 @@ contract Cars {
         CarStatus newStatus
     )
         public
-        ___(carId)
+        onlyOwner(carId)
     {
         require(
             cars[carId].status != newStatus,
@@ -53,15 +53,15 @@ contract Cars {
         cars[carId].status = newStatus;
     }
 
-    ___ onlyOwner(
-        ___ ___
+    modifier onlyOwner(
+        uint256 carId
     )
     {
         require(
             cars[carId].owner == msg.sender,
             "only owner"
         );
-        _________
+        _;
     }
 
 }

--- a/module3/contracts/10-event-logs.sol
+++ b/module3/contracts/10-event-logs.sol
@@ -4,7 +4,7 @@ contract Cars {
 
     enum CarStatus { driving, parked }
 
-    ___ CarHonk(_________);
+    event CarHonk(uint256 indexed carId);
 
     struct Car {
         bytes3 colour;
@@ -59,9 +59,9 @@ contract Cars {
         uint256 carId
     )
         public
-        _________
+        onlyOwner(carId)
     {
-        ___ CarHonk(___);
+        emit CarHonk(carId);
     }
 
     modifier onlyOwner(

--- a/module3/contracts/11-interface.sol
+++ b/module3/contracts/11-interface.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.8.0;
 
-___ ___ {
-  function count() ___ ___ returns (___);
+interface ISuperHonk {
+  function count() external view returns (uint256);
 
-  function honk() ___;
+  function honk() external;
 }
 
-contract SuperHonk is ___ {
+contract SuperHonk is ISuperHonk {
     uint256 public count;
 
     event LoudSound(address indexed source);

--- a/module3/contracts/12-reference-interface.sol
+++ b/module3/contracts/12-reference-interface.sol
@@ -32,14 +32,14 @@ contract Cars {
         address owner;
     }
 
-    ___ ___ superHonk;
+    ISuperHonk private superHonk;
     uint256 public numCars = 0;
     mapping(uint256 => Car) public cars;
 
     constructor(
-        ___ superHonkAddress
+        address superHonkAddress
     ) {
-        superHonk = ___(___);
+        superHonk = ISuperHonk(superHonkAddress);
     }
 
     function addCar(

--- a/module3/contracts/13-import.sol
+++ b/module3/contracts/13-import.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.0;
 
-___ "___";
+import { ISuperHonk } from "./13-import-target.sol";
 
 contract Cars {
 


### PR DESCRIPTION
refactor(module3/contracts): replace placeholder syntax with actual Solidity code

Replace placeholder "___" markers with proper Solidity syntax across 13 contract files including pragma declarations, contract definitions, constructors, primitive variables, enums, structs, mappings, function signatures and implementations, require statements, modifiers, events, interfaces, and imports.